### PR TITLE
Add vector column for embeddings

### DIFF
--- a/ulacm_backend/app/crud/crud_content_version.py
+++ b/ulacm_backend/app/crud/crud_content_version.py
@@ -69,6 +69,7 @@ class CRUDContentVersion(
             "version_number": next_version_number,
             "saved_by_team_id": saved_by_team_id,
             "content_vector": generate_embedding(version_in.markdown_content),
+            "vector": generate_embedding(version_in.markdown_content),
         }
         new_version = self.model(**db_obj_data)
         db.add(new_version)

--- a/ulacm_backend/app/db/models/content_version.py
+++ b/ulacm_backend/app/db/models/content_version.py
@@ -48,6 +48,7 @@ class ContentVersion(Base):
     # This column is populated by a database trigger with the tsvector of markdown_content.
     content_tsv = Column(TSVECTOR, nullable=True)
     content_vector = Column(Vector(384), nullable=True)
+    vector = Column(Vector(384), nullable=True)
 
     saved_by_team_id = Column(
         UUID(as_uuid=True),

--- a/ulacm_backend/init_db.sql
+++ b/ulacm_backend/init_db.sql
@@ -22,6 +22,9 @@ SET row_security = off;
 
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA public;
 
+-- Install pgvector extension for vector similarity search
+CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA public;
+
 
 --
 -- Name: EXTENSION "uuid-ossp"; Type: COMMENT; Schema: -; Owner:
@@ -110,7 +113,8 @@ CREATE TABLE public.content_versions (
     saved_by_team_id uuid NOT NULL,
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     content_tsv tsvector,
-    content_vector vector(384)
+    content_vector vector(384),
+    vector vector(384)
 );
 
 

--- a/ulacm_backend/tests/crud/test_crud_content_version.py
+++ b/ulacm_backend/tests/crud/test_crud_content_version.py
@@ -130,6 +130,7 @@ async def test_create_new_version_first(mock_db_session):
     assert added_obj.markdown_content == version_data.markdown_content
     assert added_obj.version_number == 1  # Should be 1 for initial version
     assert added_obj.content_vector == [0.1, 0.2]
+    assert added_obj.vector == [0.1, 0.2]
 
     # Check DB flush call (to get version_id before update)
     mock_db_session.flush.assert_awaited_once()
@@ -214,6 +215,7 @@ async def test_create_new_version_subsequent(mock_db_session):
     assert isinstance(added_obj, ContentVersion)
     assert added_obj.version_number == current_max_version + 1  # Should be incremented
     assert added_obj.content_vector == [0.3, 0.4]
+    assert added_obj.vector == [0.3, 0.4]
 
     # Check DB flush call
     mock_db_session.flush.assert_awaited_once()


### PR DESCRIPTION
## Summary
- add optional `vector` pgvector field for `ContentVersion`
- create `vector` column and enable pgvector extension in init_db
- store vectors during version creation
- adjust tests for new field

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685a5c77ab248328aea405a916d7a64d