### PR TITLE
Add retrieval service with pgvector

### DIFF
--- a/ulacm_backend/app/db/models/__init__.py
+++ b/ulacm_backend/app/db/models/__init__.py
@@ -5,3 +5,4 @@ from app.db.base_class import Base # noqa
 from .team import Team # noqa
 from .content_item import ContentItem # noqa
 from .content_version import ContentVersion # noqa
+from .document_chunk import DocumentChunk # noqa

--- a/ulacm_backend/app/db/models/content_version.py
+++ b/ulacm_backend/app/db/models/content_version.py
@@ -72,6 +72,12 @@ class ContentVersion(Base):
         "Team", back_populates="saved_versions", foreign_keys=[saved_by_team_id]
     )
 
+    chunks = relationship(
+        "DocumentChunk",
+        back_populates="version",
+        cascade="all, delete-orphan",
+    )
+
     # Constraints
     __table_args__ = (
         UniqueConstraint("item_id", "version_number", name="uq_item_version_number"),

--- a/ulacm_backend/app/db/models/document_chunk.py
+++ b/ulacm_backend/app/db/models/document_chunk.py
@@ -1,0 +1,19 @@
+from sqlalchemy import Column, ForeignKey, Integer, TEXT
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from pgvector.sqlalchemy import Vector
+import uuid
+
+from app.db.base_class import Base
+
+class DocumentChunk(Base):
+    __tablename__ = "document_chunks"
+
+    chunk_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    version_id = Column(UUID(as_uuid=True), ForeignKey("content_versions.version_id", ondelete="CASCADE"), nullable=False)
+    chunk_index = Column(Integer, nullable=False)
+    chunk_text = Column(TEXT, nullable=False)
+    embedding = Column(Vector(384), nullable=False)
+
+    version = relationship("ContentVersion", back_populates="chunks")
+

--- a/ulacm_backend/app/services/__init__.py
+++ b/ulacm_backend/app/services/__init__.py
@@ -8,6 +8,7 @@ from .workflow_parser import (
     WorkflowParsingError,
 )
 from .embedding_service import generate_embedding
+from .retrieval_service import retrieve_top_k_chunks, get_relevant_snippets
 from . import (
     workflow_service,
 )  # Imports the module itself to access its functions/classes

--- a/ulacm_backend/app/services/retrieval_service.py
+++ b/ulacm_backend/app/services/retrieval_service.py
@@ -1,0 +1,49 @@
+"""Utilities for semantic retrieval using pgvector."""
+from typing import List, Tuple
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from app.db.models.document_chunk import DocumentChunk
+from app.services.embedding_service import generate_embedding
+from app.db.models.content_version import ContentVersion
+
+def _split_text(text: str, chunk_size: int = 500) -> List[str]:
+    return [text[i:i + chunk_size] for i in range(0, len(text), chunk_size)]
+
+async def index_content_version_chunks(
+    db: AsyncSession, version: ContentVersion, chunk_size: int = 500
+) -> None:
+    """Split a document into chunks and store embeddings."""
+    chunks = _split_text(version.markdown_content, chunk_size)
+    for idx, chunk in enumerate(chunks):
+        embedding = generate_embedding(chunk)
+        db.add(
+            DocumentChunk(
+                version_id=version.version_id,
+                chunk_index=idx,
+                chunk_text=chunk,
+                embedding=embedding,
+            )
+        )
+    await db.flush()
+
+async def retrieve_top_k_chunks(
+    db: AsyncSession, query_embedding: List[float], top_k: int = 5
+) -> List[Tuple[str, float]]:
+    """Return top-k text chunks ordered by cosine similarity."""
+    stmt = (
+        select(DocumentChunk.chunk_text, DocumentChunk.embedding.cosine_distance(query_embedding).label("distance"))
+        .order_by("distance")
+        .limit(top_k)
+    )
+    result = await db.execute(stmt)
+    rows = result.all()
+    return [(row[0], row[1]) for row in rows]
+
+
+async def get_relevant_snippets(db: AsyncSession, query_text: str, top_k: int = 5) -> List[str]:
+    """Generate embedding for query_text and return relevant snippets."""
+    embedding = generate_embedding(query_text)
+    rows = await retrieve_top_k_chunks(db, embedding, top_k)
+    return [text for text, _ in rows]
+
+

--- a/ulacm_backend/init_db.sql
+++ b/ulacm_backend/init_db.sql
@@ -117,6 +117,24 @@ CREATE TABLE public.content_versions (
     vector vector(384)
 );
 
+--
+-- Name: document_chunks; Type: TABLE; Schema: public; Owner: ulacm_user
+--
+
+CREATE TABLE public.document_chunks (
+    chunk_id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    version_id uuid NOT NULL,
+    chunk_index integer NOT NULL,
+    chunk_text text NOT NULL,
+    embedding vector(384)
+);
+
+ALTER TABLE public.document_chunks OWNER TO ulacm_user;
+
+ALTER TABLE public.document_chunks
+    ADD CONSTRAINT fk_document_chunks_version FOREIGN KEY (version_id)
+        REFERENCES public.content_versions(version_id) ON DELETE CASCADE;
+
 
 ALTER TABLE public.content_versions OWNER TO ulacm_user;
 

--- a/ulacm_backend/tests/services/test_retrieval_service.py
+++ b/ulacm_backend/tests/services/test_retrieval_service.py
@@ -1,0 +1,41 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from sqlalchemy.sql import Select
+
+from app.services.retrieval_service import retrieve_top_k_chunks, get_relevant_snippets
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_retrieve_top_k_chunks_builds_query(mock_db_session):
+    query_embedding = [0.1, 0.2]
+    mock_result = MagicMock()
+    mock_result.all.return_value = [("chunk", 0.05)]
+    mock_db_session.execute = AsyncMock(return_value=mock_result)
+
+    result = await retrieve_top_k_chunks(mock_db_session, query_embedding, top_k=1)
+
+    mock_db_session.execute.assert_awaited_once()
+    stmt = mock_db_session.execute.call_args[0][0]
+    assert isinstance(stmt, Select)
+    compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "document_chunks" in compiled
+    assert "<=>" in compiled
+    assert "LIMIT 1" in compiled
+    assert result == [("chunk", 0.05)]
+
+
+async def test_get_relevant_snippets_uses_embedding(mock_db_session):
+    with patch(
+        "app.services.retrieval_service.generate_embedding",
+        return_value=[0.3, 0.4],
+    ) as mock_gen, patch(
+        "app.services.retrieval_service.retrieve_top_k_chunks",
+        AsyncMock(return_value=[("txt", 0.1)]),
+    ) as mock_retrieve:
+        snippets = await get_relevant_snippets(mock_db_session, "query", top_k=1)
+
+    mock_gen.assert_called_once_with("query")
+    mock_retrieve.assert_awaited_once_with(mock_db_session, [0.3, 0.4], 1)
+    assert snippets == ["txt"]
+


### PR DESCRIPTION
## Summary
- add `DocumentChunk` model and table
- implement semantic retrieval service with pgvector
- expose retrieval functions in services package
- add unit tests

## Testing
- `poetry run pytest` *(fails: pydantic ValidationError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685a5f80bca08328a1da0b8d949770cb